### PR TITLE
Add plugins support

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"math/rand"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -21,6 +23,14 @@ type opts struct {
 	checkFrequency string
 	destinationDir string
 	runOnce        bool
+	plugin         string
+	pluginArgs     []string
+}
+
+type plugin struct {
+	binPath string
+	name    string
+	args    []string
 }
 
 const (
@@ -33,14 +43,21 @@ func main() {
 
 	log.Print("gokrazy's selfupdate service starting up..")
 
+	gokrazy.WaitForClock()
+
 	var o opts
 
 	flag.StringVar(&o.gusServer, "gus_server", "", "the HTTP/S endpoint of the GUS (gokrazy Update System) server (required)")
 	flag.StringVar(&o.checkFrequency, "check_frequency", "1h", "the time frequency for checks to the update service. The very first check is done on startup. default: 1h")
 	flag.StringVar(&o.destinationDir, "destination_dir", "/tmp/selfupdate", "the destination directory for the fetched update file. default: /tmp/selfupdate")
 	flag.BoolVar(&o.runOnce, "run_once", false, "exits right after the initial update attempt. default: false")
+	flag.StringVar(&o.plugin, "plugin", "", "name of the desired plugin to be loaded (this will be used when needed). default: ''")
 
 	flag.Parse()
+
+	// Gather args after flag parsing termination "--".
+	// They will be directly passed to the plugin binary.
+	o.pluginArgs = flag.Args()
 
 	if err := logic(ctx, o); err != nil {
 		log.Fatal(err)
@@ -79,11 +96,16 @@ func logic(ctx context.Context, o opts) error {
 		return fmt.Errorf("error joining gus server url: %w", err)
 	}
 
+	plugins := make(map[string]plugin)
+	if err := loadPlugin(plugins, o.plugin, o.pluginArgs); err != nil {
+		return fmt.Errorf("error loading plugin %s: %w", o.plugin, err)
+	}
+
 	gusCfg := gusapi.NewConfiguration()
 	gusCfg.BasePath = gusBasePath
 	gusCli := gusapi.NewAPIClient(gusCfg)
 
-	if err := updateProcess(ctx, gusCli, machineID, o.gusServer, sbomHash, o.destinationDir, httpPassword, httpPort); err != nil {
+	if err := updateProcess(ctx, gusCli, plugins, machineID, o.gusServer, sbomHash, o.destinationDir, httpPassword, httpPort); err != nil {
 		// If the updateProcess fails we exit with an error
 		// so that gokrazy supervisor will restart the process.
 		return fmt.Errorf("error performing updateProcess: %w", err)
@@ -107,7 +129,7 @@ func logic(ctx context.Context, o opts) error {
 		case <-ticker.C:
 			jitter := time.Duration(rand.Int63n(250)) * time.Second
 			time.Sleep(jitter)
-			if err := updateProcess(ctx, gusCli, machineID, o.gusServer, sbomHash, o.destinationDir, httpPassword, httpPort); err != nil {
+			if err := updateProcess(ctx, gusCli, plugins, machineID, o.gusServer, sbomHash, o.destinationDir, httpPassword, httpPort); err != nil {
 				log.Printf("error performing updateProcess: %v", err)
 				continue
 			}
@@ -115,7 +137,7 @@ func logic(ctx context.Context, o opts) error {
 	}
 }
 
-func updateProcess(ctx context.Context, gusCli *gusapi.APIClient, machineID, gusServer, sbomHash, destinationDir, httpPassword, httpPort string) error {
+func updateProcess(ctx context.Context, gusCli *gusapi.APIClient, plugins map[string]plugin, machineID, gusServer, sbomHash, destinationDir, httpPassword, httpPort string) error {
 	response, err := checkForUpdates(ctx, gusCli, machineID)
 	if err != nil {
 		return fmt.Errorf("unable to check for updates: %w", err)
@@ -128,7 +150,7 @@ func updateProcess(ctx context.Context, gusCli *gusapi.APIClient, machineID, gus
 	}
 
 	// The SBOMHash differs, start the selfupdate procedure.
-	if err := selfupdate(ctx, gusCli, gusServer, machineID, destinationDir, response, httpPassword, httpPort); err != nil {
+	if err := selfupdate(ctx, gusCli, plugins, gusServer, machineID, destinationDir, response, httpPassword, httpPort); err != nil {
 		return fmt.Errorf("unable to perform the selfupdate procedure: %w", err)
 	}
 
@@ -137,6 +159,27 @@ func updateProcess(ctx context.Context, gusCli *gusapi.APIClient, machineID, gus
 	// sleep until the context chan is closed, then exit cleanly.
 	<-ctx.Done()
 	os.Exit(0)
+
+	return nil
+}
+
+func loadPlugin(plugins map[string]plugin, pluginName string, pluginArgs []string) error {
+	var binPath string
+
+	// Try to find the plugin binary in PATH.
+	fullPluginName := fmt.Sprintf("gokplugin-%s", pluginName)
+	if p, err := exec.LookPath(fullPluginName); err == nil {
+		binPath = p
+	} else {
+		// The binary can't be found in PATH.
+		// Fall back to checking in the well known gokrazy's /user/ path.
+		fallbackPath := fmt.Sprintf("/user/%s", fullPluginName)
+		if _, err := os.Stat(fallbackPath); errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("unable to find %s", fullPluginName)
+		}
+		binPath = fallbackPath
+	}
+	plugins[pluginName] = plugin{binPath: binPath, name: pluginName, args: pluginArgs}
 
 	return nil
 }

--- a/selfupdate.go
+++ b/selfupdate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -35,7 +36,7 @@ func shouldUpdate(response gusapi.UpdateResponse, sbomHash string) bool {
 	return true
 }
 
-func selfupdate(ctx context.Context, gusCli *gusapi.APIClient, gusServer, machineID, destinationDir string, response gusapi.UpdateResponse, httpPassword, httpPort string) error {
+func selfupdate(ctx context.Context, gusCli *gusapi.APIClient, plugins map[string]plugin, gusServer, machineID, destinationDir string, response gusapi.UpdateResponse, httpPassword, httpPort string) error {
 	log.Print("starting self-update procedure")
 
 	if _, _, err := gusCli.UpdateApi.Attempt(ctx, &gusapi.UpdateApiAttemptOpts{
@@ -52,12 +53,19 @@ func selfupdate(ctx context.Context, gusCli *gusapi.APIClient, gusServer, machin
 
 	switch response.RegistryType {
 	case "http", "localdisk":
-		readClosers, err = httpFetcher(response, gusServer, destinationDir)
+		readClosers, err = httpUpdateFetch(response, gusServer, destinationDir)
 		if err != nil {
 			return fmt.Errorf("error fetching %q update from link %q: %w", response.RegistryType, response.DownloadLink, err)
 		}
 	default:
-		return fmt.Errorf("unrecognized registry type %q", response.RegistryType)
+		if _, ok := plugins[response.RegistryType]; !ok {
+			return fmt.Errorf("error %q is not a loaded plugin", response.RegistryType)
+		}
+
+		readClosers, err = pluginFetchUpdate(ctx, plugins[response.RegistryType], destinationDir, response.DownloadLink)
+		if err != nil {
+			return fmt.Errorf("error fetching %q update from link %q: %w", response.RegistryType, response.DownloadLink, err)
+		}
 	}
 
 	uri := fmt.Sprintf("http://gokrazy:%s@localhost:%s/", httpPassword, httpPort)
@@ -99,7 +107,7 @@ func selfupdate(ctx context.Context, gusCli *gusapi.APIClient, gusServer, machin
 	}
 
 	log.Print("reboot")
-	if err := target.Reboot(ctx); err != nil {
+	if err := target.Reboot(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("reboot: %v", err)
 	}
 


### PR DESCRIPTION
As part of the update system efforts, we are introducing the ability to specify plugins that allow to push and pull updates from many different sources (e.g. OCI, S3, ...) in addition to the natively supported HTTP file server source.

As such in https://github.com/gokrazy/gokrazy/issues/173 we want to give `selfupdate` the ability to understand payload links that differ from HTTP and may be coming from a GUS update response.

To be able to do this, selfupdate must give the user the ability to specify a plugin name (which will be used by `selfupdate` to reference the plugin binary) and some credentials that the plugin will use to fetch the update from the source registries (think for example at the credentials necessary to fetch an OCI update payload from an OCI registry or at the AWS credentials necessary to pull a file from AWS S3).

This PR aims at implementing this ability for `selfupdate`.

Note:
With this approach `selfupdate` will be able to load only one plugin at a time in addition to the already natively supported HTTP fetching mechanism.