### PR TITLE
updateProcess: fix incorrect arguments, swap them back in correct order

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func logic(ctx context.Context, o opts) error {
 		case <-ticker.C:
 			jitter := time.Duration(rand.Int63n(250)) * time.Second
 			time.Sleep(jitter)
-			if err := updateProcess(ctx, gusCli, machineID, sbomHash, o.gusServer, o.destinationDir, httpPassword, httpPort); err != nil {
+			if err := updateProcess(ctx, gusCli, machineID, o.gusServer, sbomHash, o.destinationDir, httpPassword, httpPort); err != nil {
 				log.Printf("error performing updateProcess: %v", err)
 				continue
 			}


### PR DESCRIPTION
updateProcess was called with the correct arguments only in the "run once" case, but not in the periodic run case.